### PR TITLE
Fix the error message displayed when the axis limits are equal

### DIFF
--- a/python/plotting/interactive_plot.py
+++ b/python/plotting/interactive_plot.py
@@ -99,6 +99,14 @@ class InteractivePlot:
         else:
             x_min, x_max, y_min, y_max = self._calculate_simulation_axes_min_max()
 
+        if x_min == x_max:
+            x_min -= 0.5
+            x_max += 0.5
+
+        if y_min == y_max:
+            y_min -= 0.5
+            y_max += 0.5
+
         x_margin = (x_max-x_min)*AXIS_MARGIN
         y_margin = (y_max-y_min)*AXIS_MARGIN
 


### PR DESCRIPTION
This PR prevents an error message displayed by matplotlib when the axis min-max limits are equal. This is fixed by changing the limits by an arbitrary amount.

Fixes #27 