### PR TITLE
Pass Parameters by value for Constructor

### DIFF
--- a/cpp/simulator/inc/Body.h
+++ b/cpp/simulator/inc/Body.h
@@ -13,8 +13,8 @@ namespace Simulator {
 class Body {
 
 public:
-  Body(std::string const &name, double initialMass,
-       Vector2D const &initialPosition, Vector2D const &initialVelocity);
+  Body(std::string name, const double initialMass, Vector2D initialPosition,
+       Vector2D initialVelocity);
   ~Body() = default;
 
   // Sets the name of the body.

--- a/cpp/simulator/inc/Body.h
+++ b/cpp/simulator/inc/Body.h
@@ -20,19 +20,21 @@ public:
   // Sets the name of the body.
   void setName(std::string const &name);
   // Returns the name of the body.
-  [[nodiscard]] inline std::string name() const noexcept { return m_name; }
+  [[nodiscard]] inline std::string const &name() const noexcept {
+    return m_name;
+  }
 
   // Sets the initial mass of the body.
   void setInitialMass(double const mass);
   // Returns the mass of the body.
-  [[nodiscard]] inline double initialMass() const noexcept {
+  [[nodiscard]] inline double const initialMass() const noexcept {
     return m_initialMass;
   }
 
   // Sets the current mass of the body.
   void setMass(double const mass);
   // Returns the current mass of the body.
-  [[nodiscard]] inline double mass() const noexcept { return m_mass; }
+  [[nodiscard]] inline double const mass() const noexcept { return m_mass; }
 
   // Returns the initial position of the body.
   [[nodiscard]] inline Vector2D &initialPosition() noexcept {
@@ -49,7 +51,7 @@ public:
   [[nodiscard]] inline Vector2D &velocity() noexcept { return m_velocity; }
 
   // Returns an estimated radius for the body.
-  [[nodiscard]] double radius() const;
+  [[nodiscard]] double const radius() const;
 
   // Reset the position and velocity of the body to the initial values.
   void resetBody();
@@ -57,9 +59,11 @@ public:
   // Sets the body as having been engulfed by a larger body.
   void setAsMerged(bool const merged);
   // Returns true if this body has merged into a larger body.
-  [[nodiscard]] inline bool isMerged() const noexcept { return m_isMerged; }
+  [[nodiscard]] inline bool const isMerged() const noexcept {
+    return m_isMerged;
+  }
 
-  bool operator!=(Body const &otherBody);
+  bool const operator!=(Body const &otherBody);
 
 private:
   std::string m_name;

--- a/cpp/simulator/inc/Body.h
+++ b/cpp/simulator/inc/Body.h
@@ -23,14 +23,14 @@ public:
   [[nodiscard]] inline std::string name() const noexcept { return m_name; }
 
   // Sets the initial mass of the body.
-  void setInitialMass(double mass);
+  void setInitialMass(double const mass);
   // Returns the mass of the body.
   [[nodiscard]] inline double initialMass() const noexcept {
     return m_initialMass;
   }
 
   // Sets the current mass of the body.
-  void setMass(double mass);
+  void setMass(double const mass);
   // Returns the current mass of the body.
   [[nodiscard]] inline double mass() const noexcept { return m_mass; }
 
@@ -55,7 +55,7 @@ public:
   void resetBody();
 
   // Sets the body as having been engulfed by a larger body.
-  void setAsMerged(bool merged);
+  void setAsMerged(bool const merged);
   // Returns true if this body has merged into a larger body.
   [[nodiscard]] inline bool isMerged() const noexcept { return m_isMerged; }
 

--- a/cpp/simulator/inc/Body.h
+++ b/cpp/simulator/inc/Body.h
@@ -13,7 +13,7 @@ namespace Simulator {
 class Body {
 
 public:
-  Body(std::string name, const double initialMass, Vector2D initialPosition,
+  Body(std::string name, double const initialMass, Vector2D initialPosition,
        Vector2D initialVelocity);
   ~Body() = default;
 

--- a/cpp/simulator/inc/BodyPositionsAndVelocities.h
+++ b/cpp/simulator/inc/BodyPositionsAndVelocities.h
@@ -26,11 +26,11 @@ public:
   [[nodiscard]] Body &body() const;
 
   // Add a mass for a specific time.
-  void addMass(double time, double mass);
+  void addMass(double const time, double const mass);
   // Add a position coordinate for a specific time.
-  void addPosition(double time, Vector2D const &position);
+  void addPosition(double const time, Vector2D const &position);
   // Add a velocity for a specific time.
-  void addVelocity(double time, Vector2D const &velocity);
+  void addVelocity(double const time, Vector2D const &velocity);
 
   // Returns the bodies mass at the different times during the a simulation.
   [[nodiscard]] inline std::map<double, double> masses() const noexcept {

--- a/cpp/simulator/inc/BodyPositionsAndVelocities.h
+++ b/cpp/simulator/inc/BodyPositionsAndVelocities.h
@@ -33,17 +33,19 @@ public:
   void addVelocity(double const time, Vector2D const &velocity);
 
   // Returns the bodies mass at the different times during the a simulation.
-  [[nodiscard]] inline std::map<double, double> masses() const noexcept {
+  [[nodiscard]] inline std::map<double, double> const &masses() const noexcept {
     return m_masses;
   }
 
   // Returns the body locations calculated during a simulation.
-  [[nodiscard]] inline std::map<double, Vector2D> positions() const noexcept {
+  [[nodiscard]] inline std::map<double, Vector2D> const &
+  positions() const noexcept {
     return m_positions;
   }
 
   // Returns the body velocities calculated during a simulation.
-  [[nodiscard]] inline std::map<double, Vector2D> velocities() const noexcept {
+  [[nodiscard]] inline std::map<double, Vector2D> const &
+  velocities() const noexcept {
     return m_velocities;
   }
 

--- a/cpp/simulator/inc/NBodySimulator.h
+++ b/cpp/simulator/inc/NBodySimulator.h
@@ -36,18 +36,18 @@ public:
   // Set the time step used by the simulator.
   void setTimeStep(double const timeStep);
   // Return the time step stored by the simulator.
-  [[nodiscard]] double timeStep() const;
+  [[nodiscard]] double const timeStep() const;
 
   // Set the simulation duration used by the simulator.
   void setDuration(double const duration);
   // Return the simulation duration stored by the simulator.
-  [[nodiscard]] double duration() const;
+  [[nodiscard]] double const duration() const;
 
   // Return the number of bodies in the simulation setup.
-  [[nodiscard]] std::size_t numberOfBodies() const;
+  [[nodiscard]] std::size_t const numberOfBodies() const;
 
   // Returns the names of the bodies in the simulator.
-  [[nodiscard]] std::vector<std::string> bodyNames() const;
+  [[nodiscard]] std::vector<std::string> const bodyNames() const;
 
   // Set a new name for the specified body in the simulator.
   void setName(std::string const &oldName, std::string const &newName);
@@ -55,7 +55,7 @@ public:
   // Set the mass of the specified body in the simulator.
   void setMass(std::string const &bodyName, double const mass);
   // Return the mass of the specified body stored by the simulator.
-  double initialMass(std::string const &bodyName) const;
+  double const initialMass(std::string const &bodyName) const;
 
   // Set the x position of the specified body in the simulator.
   void setXPosition(std::string const &bodyName, double const x);
@@ -68,23 +68,24 @@ public:
   void setYVelocity(std::string const &bodyName, double const vy);
 
   // Return the initial position of the specified body stored by the simulator.
-  Vector2D initialPosition(std::string const &bodyName) const;
+  Vector2D const initialPosition(std::string const &bodyName) const;
   // Return the initial velocity of the specified body stored by the simulator.
-  Vector2D initialVelocity(std::string const &bodyName) const;
+  Vector2D const initialVelocity(std::string const &bodyName) const;
 
   // Returns true if the initial parameters changed since the last simulation.
-  [[nodiscard]] bool hasDataChanged() const;
+  [[nodiscard]] bool const hasDataChanged() const;
 
   // Run the simulation using the currently stored initial parameters.
   void runSimulation();
 
   // Return the simulated masses of the specified body.
-  std::map<double, double> simulatedMasses(std::string const &bodyName) const;
+  std::map<double, double> const
+  simulatedMasses(std::string const &bodyName) const;
   // Return the simulated locations of the specified body.
-  std::map<double, Vector2D>
+  std::map<double, Vector2D> const
   simulatedPositions(std::string const &bodyName) const;
   // Return the simulated velocities of the specified body.
-  std::map<double, Vector2D>
+  std::map<double, Vector2D> const
   simulatedVelocities(std::string const &bodyName) const;
 
 private:
@@ -121,7 +122,7 @@ private:
   // Finds the Body data object given a bodies name.
   Body &findBody(std::string const &name) const;
   // Finds the index of the specified body in m_bodyData.
-  std::size_t findBodyIndex(std::string const &name) const;
+  std::size_t const findBodyIndex(std::string const &name) const;
 
   double m_timeStep;
   double m_duration;

--- a/cpp/simulator/inc/NBodySimulator.h
+++ b/cpp/simulator/inc/NBodySimulator.h
@@ -20,6 +20,8 @@ class NBodySimulator {
 
 public:
   NBodySimulator();
+  NBodySimulator(NBodySimulator const &simulator) = delete;
+  NBodySimulator &operator=(NBodySimulator const &simulator) = delete;
   ~NBodySimulator();
 
   // Clear all the data from the simulator

--- a/cpp/simulator/inc/NBodySimulator.h
+++ b/cpp/simulator/inc/NBodySimulator.h
@@ -28,16 +28,16 @@ public:
   // Removes the body with the specified name from the simulator.
   void removeBody(std::string const &name);
   // Adds a body to the simulator.
-  void addBody(std::string const &name, double mass, Vector2D const &position,
-               Vector2D const &velocity);
+  void addBody(std::string const &name, double const mass,
+               Vector2D const &position, Vector2D const &velocity);
 
   // Set the time step used by the simulator.
-  void setTimeStep(double timeStep);
+  void setTimeStep(double const timeStep);
   // Return the time step stored by the simulator.
   [[nodiscard]] double timeStep() const;
 
   // Set the simulation duration used by the simulator.
-  void setDuration(double duration);
+  void setDuration(double const duration);
   // Return the simulation duration stored by the simulator.
   [[nodiscard]] double duration() const;
 
@@ -51,19 +51,19 @@ public:
   void setName(std::string const &oldName, std::string const &newName);
 
   // Set the mass of the specified body in the simulator.
-  void setMass(std::string const &bodyName, double mass);
+  void setMass(std::string const &bodyName, double const mass);
   // Return the mass of the specified body stored by the simulator.
   double initialMass(std::string const &bodyName) const;
 
   // Set the x position of the specified body in the simulator.
-  void setXPosition(std::string const &bodyName, double x);
+  void setXPosition(std::string const &bodyName, double const x);
   // Set the y position of the specified body in the simulator.
-  void setYPosition(std::string const &bodyName, double y);
+  void setYPosition(std::string const &bodyName, double const y);
 
   // Set the x velocity of the specified body in the simulator.
-  void setXVelocity(std::string const &bodyName, double vx);
+  void setXVelocity(std::string const &bodyName, double const vx);
   // Set the y velocity of the specified body in the simulator.
-  void setYVelocity(std::string const &bodyName, double vy);
+  void setYVelocity(std::string const &bodyName, double const vy);
 
   // Return the initial position of the specified body stored by the simulator.
   Vector2D initialPosition(std::string const &bodyName) const;

--- a/cpp/simulator/inc/SimulationConstants.h
+++ b/cpp/simulator/inc/SimulationConstants.h
@@ -15,11 +15,11 @@ static double AU(1.49598e+11);      // Astronomical unit (m)
 static double DAY(60.0 * 60.0 * 24.0); // Day (s)
 
 // Calculates the gravitational constant for the specified time unit.
-[[nodiscard]] double gravitationalConstant(TimeUnit const &timeUnit);
+[[nodiscard]] double const gravitationalConstant(TimeUnit const &timeUnit);
 
 // Returns a pseudo value to use for the density of a body. These densities are
 // not based in reality.
-[[nodiscard]] double density(double const mass);
+[[nodiscard]] double const density(double const mass);
 
 } // namespace Constants
 } // namespace Simulator

--- a/cpp/simulator/inc/SimulationConstants.h
+++ b/cpp/simulator/inc/SimulationConstants.h
@@ -19,7 +19,7 @@ static double DAY(60.0 * 60.0 * 24.0); // Day (s)
 
 // Returns a pseudo value to use for the density of a body. These densities are
 // not based in reality.
-[[nodiscard]] double density(double mass);
+[[nodiscard]] double density(double const mass);
 
 } // namespace Constants
 } // namespace Simulator

--- a/cpp/simulator/inc/Vector2D.h
+++ b/cpp/simulator/inc/Vector2D.h
@@ -12,7 +12,7 @@ struct Vector2D {
 
   // Used to simplify vector operations.
   Vector2D operator-(Vector2D const &otherVector);
-  Vector2D operator*(double value);
+  Vector2D operator*(double const value);
   void operator+=(Vector2D const &otherVector);
   bool operator==(Vector2D const &otherVector);
 

--- a/cpp/simulator/inc/Vector2D.h
+++ b/cpp/simulator/inc/Vector2D.h
@@ -8,13 +8,13 @@ namespace Simulator {
 // A struct used for two dimensional vector operations.
 struct Vector2D {
   // Calculates the magnitude of the two dimensional vector.
-  [[nodiscard]] double magnitude() const;
+  [[nodiscard]] double const magnitude() const;
 
   // Used to simplify vector operations.
-  Vector2D operator-(Vector2D const &otherVector);
-  Vector2D operator*(double const value);
+  Vector2D const operator-(Vector2D const &otherVector);
+  Vector2D const operator*(double const value);
   void operator+=(Vector2D const &otherVector);
-  bool operator==(Vector2D const &otherVector);
+  bool const operator==(Vector2D const &otherVector);
 
   double m_x;
   double m_y;

--- a/cpp/simulator/src/Body.cpp
+++ b/cpp/simulator/src/Body.cpp
@@ -15,7 +15,7 @@ Body::Body(std::string name, double const initialMass, Vector2D initialPosition,
     : m_name(std::move(name)), m_initialMass(initialMass),
       m_initialPosition(std::move(initialPosition)),
       m_initialVelocity(std::move(initialVelocity)), m_mass(initialMass),
-      m_position(initialPosition), m_velocity(initialVelocity),
+      m_position(m_initialPosition), m_velocity(m_initialVelocity),
       m_isMerged(false) {}
 
 void Body::setName(std::string const &name) { m_name = name; }

--- a/cpp/simulator/src/Body.cpp
+++ b/cpp/simulator/src/Body.cpp
@@ -20,12 +20,12 @@ Body::Body(std::string name, double const initialMass, Vector2D initialPosition,
 
 void Body::setName(std::string const &name) { m_name = name; }
 
-void Body::setInitialMass(double mass) {
+void Body::setInitialMass(double const mass) {
   m_initialMass = mass;
   m_mass = mass;
 }
 
-void Body::setMass(double mass) { m_mass = mass; }
+void Body::setMass(double const mass) { m_mass = mass; }
 
 double Body::radius() const {
   return pow((3.0 * m_mass) / (4.0 * M_PI * Constants::density(m_mass)),
@@ -39,7 +39,7 @@ void Body::resetBody() {
   m_isMerged = false;
 }
 
-void Body::setAsMerged(bool merged) { m_isMerged = merged; }
+void Body::setAsMerged(bool const merged) { m_isMerged = merged; }
 
 bool Body::operator!=(Body const &otherBody) {
   return m_name != otherBody.name();

--- a/cpp/simulator/src/Body.cpp
+++ b/cpp/simulator/src/Body.cpp
@@ -27,7 +27,7 @@ void Body::setInitialMass(double const mass) {
 
 void Body::setMass(double const mass) { m_mass = mass; }
 
-double Body::radius() const {
+double const Body::radius() const {
   return pow((3.0 * m_mass) / (4.0 * M_PI * Constants::density(m_mass)),
              (1.0 / 3.0));
 }
@@ -41,7 +41,7 @@ void Body::resetBody() {
 
 void Body::setAsMerged(bool const merged) { m_isMerged = merged; }
 
-bool Body::operator!=(Body const &otherBody) {
+bool const Body::operator!=(Body const &otherBody) {
   return m_name != otherBody.name();
 }
 

--- a/cpp/simulator/src/Body.cpp
+++ b/cpp/simulator/src/Body.cpp
@@ -10,12 +10,13 @@
 
 namespace Simulator {
 
-Body::Body(std::string const &name, double initialMass,
-           Vector2D const &initialPosition, Vector2D const &initialVelocity)
-    : m_name(name), m_initialMass(initialMass),
-      m_initialPosition(initialPosition), m_initialVelocity(initialVelocity),
-      m_mass(initialMass), m_position(initialPosition),
-      m_velocity(initialVelocity), m_isMerged(false) {}
+Body::Body(std::string name, double const initialMass, Vector2D initialPosition,
+           Vector2D initialVelocity)
+    : m_name(std::move(name)), m_initialMass(initialMass),
+      m_initialPosition(std::move(initialPosition)),
+      m_initialVelocity(std::move(initialVelocity)), m_mass(initialMass),
+      m_position(initialPosition), m_velocity(initialVelocity),
+      m_isMerged(false) {}
 
 void Body::setName(std::string const &name) { m_name = name; }
 

--- a/cpp/simulator/src/BodyPositionsAndVelocities.cpp
+++ b/cpp/simulator/src/BodyPositionsAndVelocities.cpp
@@ -32,7 +32,7 @@ void BodyPositionsAndVelocities::resetParameters() {
 
 Body &BodyPositionsAndVelocities::body() const { return *m_body.get(); }
 
-void BodyPositionsAndVelocities::addMass(double time, double mass) {
+void BodyPositionsAndVelocities::addMass(double const time, double const mass) {
   if (m_masses.find(time) != m_masses.cend())
     throw std::runtime_error("A mass for " + m_body->name() + " at time " +
                              std::to_string(time) + " already exists.");
@@ -40,7 +40,7 @@ void BodyPositionsAndVelocities::addMass(double time, double mass) {
   m_masses[time] = mass;
 }
 
-void BodyPositionsAndVelocities::addPosition(double time,
+void BodyPositionsAndVelocities::addPosition(double const time,
                                              Vector2D const &position) {
   if (m_positions.find(time) != m_positions.cend())
     throw std::runtime_error("A position for " + m_body->name() + " at time " +
@@ -49,7 +49,7 @@ void BodyPositionsAndVelocities::addPosition(double time,
   m_positions[time] = position;
 }
 
-void BodyPositionsAndVelocities::addVelocity(double time,
+void BodyPositionsAndVelocities::addVelocity(double const time,
                                              Vector2D const &velocity) {
   if (m_velocities.find(time) != m_velocities.cend())
     throw std::runtime_error("A velocity for " + m_body->name() + " at time " +

--- a/cpp/simulator/src/NBodySimulator.cpp
+++ b/cpp/simulator/src/NBodySimulator.cpp
@@ -49,18 +49,20 @@ void NBodySimulator::setTimeStep(double const timeStep) {
   m_dataChanged = true;
 }
 
-double NBodySimulator::timeStep() const { return m_timeStep; }
+double const NBodySimulator::timeStep() const { return m_timeStep; }
 
 void NBodySimulator::setDuration(double const duration) {
   m_duration = duration;
   m_dataChanged = true;
 }
 
-double NBodySimulator::duration() const { return m_duration; }
+double const NBodySimulator::duration() const { return m_duration; }
 
-std::size_t NBodySimulator::numberOfBodies() const { return m_bodyData.size(); }
+std::size_t const NBodySimulator::numberOfBodies() const {
+  return m_bodyData.size();
+}
 
-std::vector<std::string> NBodySimulator::bodyNames() const {
+std::vector<std::string> const NBodySimulator::bodyNames() const {
   auto const getName =
       [](std::unique_ptr<BodyPositionsAndVelocities> const &data) {
         return data->body().name();
@@ -89,7 +91,7 @@ void NBodySimulator::setMass(std::string const &bodyName, double const mass) {
   m_dataChanged = true;
 }
 
-double NBodySimulator::initialMass(std::string const &bodyName) const {
+double const NBodySimulator::initialMass(std::string const &bodyName) const {
   return findBody(bodyName).initialMass();
 }
 
@@ -115,15 +117,17 @@ void NBodySimulator::setYVelocity(std::string const &bodyName,
   m_dataChanged = true;
 }
 
-Vector2D NBodySimulator::initialPosition(std::string const &bodyName) const {
+Vector2D const
+NBodySimulator::initialPosition(std::string const &bodyName) const {
   return findBody(bodyName).initialPosition();
 }
 
-Vector2D NBodySimulator::initialVelocity(std::string const &bodyName) const {
+Vector2D const
+NBodySimulator::initialVelocity(std::string const &bodyName) const {
   return findBody(bodyName).initialVelocity();
 }
 
-bool NBodySimulator::hasDataChanged() const { return m_dataChanged; }
+bool const NBodySimulator::hasDataChanged() const { return m_dataChanged; }
 
 void NBodySimulator::runSimulation() {
   validateSimulationParameters();
@@ -141,19 +145,19 @@ void NBodySimulator::runSimulation() {
   m_dataChanged = false;
 }
 
-std::map<double, double>
+std::map<double, double> const
 NBodySimulator::simulatedMasses(std::string const &bodyName) const {
   auto const bodyIndex = findBodyIndex(bodyName);
   return m_bodyData[bodyIndex]->masses();
 }
 
-std::map<double, Vector2D>
+std::map<double, Vector2D> const
 NBodySimulator::simulatedPositions(std::string const &bodyName) const {
   auto const bodyIndex = findBodyIndex(bodyName);
   return m_bodyData[bodyIndex]->positions();
 }
 
-std::map<double, Vector2D>
+std::map<double, Vector2D> const
 NBodySimulator::simulatedVelocities(std::string const &bodyName) const {
   auto const bodyIndex = findBodyIndex(bodyName);
   return m_bodyData[bodyIndex]->velocities();
@@ -255,7 +259,7 @@ Body &NBodySimulator::findBody(std::string const &name) const {
   return m_bodyData[findBodyIndex(name)]->body();
 }
 
-std::size_t NBodySimulator::findBodyIndex(std::string const &name) const {
+std::size_t const NBodySimulator::findBodyIndex(std::string const &name) const {
   auto const hasName =
       [&](std::unique_ptr<BodyPositionsAndVelocities> const &data) {
         return data->body().name() == name;

--- a/cpp/simulator/src/NBodySimulator.cpp
+++ b/cpp/simulator/src/NBodySimulator.cpp
@@ -33,7 +33,7 @@ void NBodySimulator::removeBody(std::string const &name) {
   m_dataChanged = true;
 }
 
-void NBodySimulator::addBody(std::string const &name, double mass,
+void NBodySimulator::addBody(std::string const &name, double const mass,
                              Vector2D const &position,
                              Vector2D const &velocity) {
   if (hasBody(name))
@@ -44,14 +44,14 @@ void NBodySimulator::addBody(std::string const &name, double mass,
   m_dataChanged = true;
 }
 
-void NBodySimulator::setTimeStep(double timeStep) {
+void NBodySimulator::setTimeStep(double const timeStep) {
   m_timeStep = timeStep;
   m_dataChanged = true;
 }
 
 double NBodySimulator::timeStep() const { return m_timeStep; }
 
-void NBodySimulator::setDuration(double duration) {
+void NBodySimulator::setDuration(double const duration) {
   m_duration = duration;
   m_dataChanged = true;
 }
@@ -82,7 +82,7 @@ void NBodySimulator::setName(std::string const &oldName,
   m_dataChanged = true;
 }
 
-void NBodySimulator::setMass(std::string const &bodyName, double mass) {
+void NBodySimulator::setMass(std::string const &bodyName, double const mass) {
   auto &body = findBody(bodyName);
   body.setInitialMass(mass);
   body.setMass(mass);
@@ -93,22 +93,24 @@ double NBodySimulator::initialMass(std::string const &bodyName) const {
   return findBody(bodyName).initialMass();
 }
 
-void NBodySimulator::setXPosition(std::string const &bodyName, double x) {
+void NBodySimulator::setXPosition(std::string const &bodyName, double const x) {
   findBody(bodyName).initialPosition().m_x = x;
   m_dataChanged = true;
 }
 
-void NBodySimulator::setYPosition(std::string const &bodyName, double y) {
+void NBodySimulator::setYPosition(std::string const &bodyName, double const y) {
   findBody(bodyName).initialPosition().m_y = y;
   m_dataChanged = true;
 }
 
-void NBodySimulator::setXVelocity(std::string const &bodyName, double vx) {
+void NBodySimulator::setXVelocity(std::string const &bodyName,
+                                  double const vx) {
   findBody(bodyName).initialVelocity().m_x = vx;
   m_dataChanged = true;
 }
 
-void NBodySimulator::setYVelocity(std::string const &bodyName, double vy) {
+void NBodySimulator::setYVelocity(std::string const &bodyName,
+                                  double const vy) {
   findBody(bodyName).initialVelocity().m_y = vy;
   m_dataChanged = true;
 }

--- a/cpp/simulator/src/SimulationConstants.cpp
+++ b/cpp/simulator/src/SimulationConstants.cpp
@@ -8,7 +8,7 @@
 namespace Simulator {
 namespace Constants {
 
-double gravitationalConstant(TimeUnit const &timeUnit) {
+double const gravitationalConstant(TimeUnit const &timeUnit) {
   switch (timeUnit) {
   case TimeUnit::Days:
     return G * M_SOLAR * pow(DAY, 2) * (1.0 / pow(AU, 3));
@@ -17,7 +17,7 @@ double gravitationalConstant(TimeUnit const &timeUnit) {
   throw std::invalid_argument("An invalid time unit has been provided.");
 }
 
-double density(double const mass) {
+double const density(double const mass) {
   double densityKgPerMetreCubed;
   if (mass <= 0.0001)
     densityKgPerMetreCubed = 0.1;

--- a/cpp/simulator/src/SimulationConstants.cpp
+++ b/cpp/simulator/src/SimulationConstants.cpp
@@ -17,7 +17,7 @@ double gravitationalConstant(TimeUnit const &timeUnit) {
   throw std::invalid_argument("An invalid time unit has been provided.");
 }
 
-double density(double mass) {
+double density(double const mass) {
   double densityKgPerMetreCubed;
   if (mass <= 0.0001)
     densityKgPerMetreCubed = 0.1;

--- a/cpp/simulator/src/Vector2D.cpp
+++ b/cpp/simulator/src/Vector2D.cpp
@@ -6,15 +6,15 @@
 
 namespace Simulator {
 
-double Vector2D::magnitude() const {
+double const Vector2D::magnitude() const {
   return pow(pow(m_x, 2) + pow(m_y, 2), 0.5);
 }
 
-Vector2D Vector2D::operator-(Vector2D const &otherVector) {
+Vector2D const Vector2D::operator-(Vector2D const &otherVector) {
   return {m_x - otherVector.m_x, m_y - otherVector.m_y};
 }
 
-Vector2D Vector2D::operator*(double const value) {
+Vector2D const Vector2D::operator*(double const value) {
   return {m_x * value, m_y * value};
 }
 
@@ -23,7 +23,7 @@ void Vector2D::operator+=(Vector2D const &otherVector) {
   m_y += otherVector.m_y;
 }
 
-bool Vector2D::operator==(Vector2D const &otherVector) {
+bool const Vector2D::operator==(Vector2D const &otherVector) {
   return m_x == otherVector.m_x && m_y == otherVector.m_y;
 }
 

--- a/cpp/simulator/src/Vector2D.cpp
+++ b/cpp/simulator/src/Vector2D.cpp
@@ -14,7 +14,7 @@ Vector2D Vector2D::operator-(Vector2D const &otherVector) {
   return {m_x - otherVector.m_x, m_y - otherVector.m_y};
 }
 
-Vector2D Vector2D::operator*(double value) {
+Vector2D Vector2D::operator*(double const value) {
   return {m_x * value, m_y * value};
 }
 

--- a/python/exports/NBodySimulator.cpp
+++ b/python/exports/NBodySimulator.cpp
@@ -19,7 +19,7 @@ void export_NBodySimulator(py::module &m) {
                &Simulator::NBodySimulator::removeBody),
            py::arg("name"))
       .def("addBody",
-           py::overload_cast<std::string const &, double,
+           py::overload_cast<std::string const &, double const,
                              Simulator::Vector2D const &,
                              Simulator::Vector2D const &>(
                &Simulator::NBodySimulator::addBody),
@@ -45,7 +45,7 @@ void export_NBodySimulator(py::module &m) {
                &Simulator::NBodySimulator::setName),
            py::arg("oldName"), py::arg("newName"))
       .def("setMass",
-           py::overload_cast<std::string const &, double>(
+           py::overload_cast<std::string const &, double const>(
                &Simulator::NBodySimulator::setMass),
            py::arg("bodyName"), py::arg("mass"))
       .def("initialMass",
@@ -53,19 +53,19 @@ void export_NBodySimulator(py::module &m) {
                &Simulator::NBodySimulator::initialMass, py::const_),
            py::arg("bodyName"))
       .def("setXPosition",
-           py::overload_cast<std::string const &, double>(
+           py::overload_cast<std::string const &, double const>(
                &Simulator::NBodySimulator::setXPosition),
            py::arg("bodyName"), py::arg("x"))
       .def("setYPosition",
-           py::overload_cast<std::string const &, double>(
+           py::overload_cast<std::string const &, double const>(
                &Simulator::NBodySimulator::setYPosition),
            py::arg("bodyName"), py::arg("y"))
       .def("setXVelocity",
-           py::overload_cast<std::string const &, double>(
+           py::overload_cast<std::string const &, double const>(
                &Simulator::NBodySimulator::setXVelocity),
            py::arg("bodyName"), py::arg("vx"))
       .def("setYVelocity",
-           py::overload_cast<std::string const &, double>(
+           py::overload_cast<std::string const &, double const>(
                &Simulator::NBodySimulator::setYVelocity),
            py::arg("bodyName"), py::arg("vy"))
       .def("initialPosition",


### PR DESCRIPTION
Pass parameters to constructors by value because this doesn't avoid a copy for r-values. Instead, the r-values can be moved into the member field after being passed to the constructor by value.

Refs #111