### PR TITLE
Add missing package installations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # These are the requirements necessary for building the project, not running it.
 cmake
+cycler
+pillow
 pybind11>=2.9.0
 # pyside2 and PyQt5 are project dependencies and so should ideally be installed using the install_requires keyword in the
 # setup.py. But there is a problem: https://stackoverflow.com/questions/38488063/add-pyqt5-to-install-require


### PR DESCRIPTION
Installs `cycler` and `pillow` because installing this package doesn't work without them